### PR TITLE
This PR fixes 5 issues thanks to snyk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 openjdk:11.0.13-slim-buster
+FROM --platform=linux/amd64 openjdk:11.0.16-jdk-slim-bullseye
 #FROM --platform=linux/amd64 openjdk:21-slim-bullseye
 
 RUN addgroup --system javauser && adduser --system --home /home/javauser --ingroup javauser javauser


### PR DESCRIPTION
It updates openjdk from version 11.0.13-slim-buster to version 11.0.16-jdk-slim-bullseye.
Review relevant docs for possible breaking changes.


To find more details, see the Snyk project [Witnull&#x2F;snyk-boot-web:Dockerfile](https:&#x2F;&#x2F;app.snyk.io&#x2F;org&#x2F;witnull&#x2F;project&#x2F;b4008b54-23f1-4c0f-8ec5-8f089424fa70?utm_source&#x3D;github&amp;utm_medium&#x3D;referral&amp;page&#x3D;fix-pr)


[//]: # 'snyk:metadata:{"customTemplate":{"variablesUsed":["issue_count","package_name","package_from","package_to","snyk_project_name","snyk_project_url"],"fieldsUsed":["commitMessage","description","title"]},"dependencies":[{"name":"openjdk","from":"11.0.13-slim-buster","to":"11.0.16-jdk-slim-bullseye"}],"env":"prod","issuesToFix":["SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-GLIBC-1296899","SNYK-DEBIAN10-GLIBC-1315333","SNYK-DEBIAN10-GLIBC-2340915"],"prId":"6f67cbd2-8135-4d65-944b-663a88651a76","prPublicId":"6f67cbd2-8135-4d65-944b-663a88651a76","packageManager":"dockerfile","priorityScoreList":[786,714,714,714],"projectPublicId":"b4008b54-23f1-4c0f-8ec5-8f089424fa70","projectUrl":"https://app.snyk.io/org/witnull/project/b4008b54-23f1-4c0f-8ec5-8f089424fa70?utm_source=github&utm_medium=referral&page=fix-pr","prType":"fix","templateFieldSources":{"branchName":"default","commitMessage":"repository","description":"repository","title":"repository"},"templateVariants":["custom","updated-fix-title","priorityScore"],"type":"user-initiated","upgrade":["SNYK-DEBIAN10-GLIBC-1296899","SNYK-DEBIAN10-GLIBC-1315333","SNYK-DEBIAN10-GLIBC-2340915","SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-SYSTEMD-3339153"],"vulns":["SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-GLIBC-1296899","SNYK-DEBIAN10-GLIBC-1315333","SNYK-DEBIAN10-GLIBC-2340915"],"patch":[],"isBreakingChange":false,"remediationStrategy":"vuln"}'